### PR TITLE
Install cmake configurations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,4 +26,8 @@ elseif(${CMAKE_Fortran_COMPILER_ID} MATCHES PGI)
 endif(${CMAKE_Fortran_COMPILER_ID} MATCHES GNU)
 
 add_subdirectory(src)
-add_subdirectory(test)
+
+find_package(pFUnit 3.2.9)
+if(${pFUnit_FOUND})
+    add_subdirectory(test)
+endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,6 +10,7 @@ target_include_directories(callpy PUBLIC
     )
 
 install(TARGETS callpy
+    EXPORT callpy
     RUNTIME DESTINATION bin
     LIBRARY DESTINATION lib
     ARCHIVE DESTINATION lib
@@ -19,6 +20,11 @@ install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/ DESTINATION include
     FILES_MATCHING PATTERN "*.mod"
     PATTERN "CMakeFiles" EXCLUDE
     )
+install(EXPORT callpy
+    FILE CallPyFortConfig.cmake
+    DESTINATION lib/cmake/CallPyFort
+    NAMESPACE CallPyFort::
+)
 
 add_custom_command(
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/plugin.c


### PR DESCRIPTION
This allows this package to be discovered within other projects by the following to CMakeLists.txt
```
find_package(CallPyFort)
```
