### PR TITLE
Use the new python FindPackage cmake module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ elseif(${CMAKE_Fortran_COMPILER_ID} MATCHES PGI)
 
 endif(${CMAKE_Fortran_COMPILER_ID} MATCHES GNU)
 
+
 add_subdirectory(src)
 
 find_package(pFUnit 3.2.9)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ post](https://www.noahbrenowitz.com/post/calling-fortran-from-python/).
 
 This library has the following dependencies
 1. pfUnit (v3.2.9) for the unit tests
-1. python (3+) with numpy and cffi
+1. python (3+) with numpy and cffi, with libpython built as a shared library.
 1. cmake (>=3.4+)
 
 To install pfunit on a linux system, you can run a commmand like the following:
@@ -96,3 +96,5 @@ point of one, two, or three dimensions.
 ## Examples
 
 See the [unit tests](/test/test_call_py_fort.pfunit) for more examples.
+
+

--- a/pfunit.nix
+++ b/pfunit.nix
@@ -1,4 +1,4 @@
-{ stdenv, m4, fetchFromGitHub, gfortran, cmake, python3 }:
+{ stdenv, lib, m4, fetchFromGitHub, gfortran, cmake, python3 }:
 stdenv.mkDerivation {
   name = "pFUnit";
   src = fetchFromGitHub {
@@ -11,4 +11,9 @@ stdenv.mkDerivation {
   };
   buildInputs = [ python3 gfortran cmake gfortran.cc m4 ];
 
+  # disable stackprotector on aarch64-darwin for now
+  # https://github.com/NixOS/nixpkgs/issues/158730
+  # see https://github.com/NixOS/nixpkgs/issues/127608 for a similar issue
+  hardeningDisable =
+    lib.optionals (stdenv.isAarch64 && stdenv.isDarwin) [ "stackprotector" ];
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,6 +3,10 @@ set(Python_USE_STATIC_LIBS FALSE)
 find_package(Python 3 REQUIRED COMPONENTS Interpreter Development)
 add_library(callpy SHARED callpy_mod.f90 ${CMAKE_CURRENT_BINARY_DIR}/plugin.c)
 target_link_libraries(callpy PUBLIC Python::Python)
+target_include_directories(callpy PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+    $<INSTALL_INTERFACE:include/callpy>
+)
 
 
 install(TARGETS callpy
@@ -10,6 +14,7 @@ install(TARGETS callpy
     RUNTIME DESTINATION bin
     LIBRARY DESTINATION lib
     ARCHIVE DESTINATION lib
+    INCLUDES DESTINATION include
     )
 
 install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/ DESTINATION include
@@ -28,3 +33,4 @@ add_custom_command(
   COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/builder.py ${CMAKE_CURRENT_SOURCE_DIR}/callpy.py
   COMMENT "Building CFFI Module"
 )
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,13 +1,9 @@
-find_package(PythonInterp 3 REQUIRED)
-find_package(PythonLibs 3 REQUIRED)
-
+set(Python_FIND_VIRTUALENV ONLY)
+set(Python_USE_STATIC_LIBS FALSE)
+find_package(Python 3 REQUIRED COMPONENTS Interpreter Development)
 add_library(callpy SHARED callpy_mod.f90 ${CMAKE_CURRENT_BINARY_DIR}/plugin.c)
-target_link_libraries(callpy ${PYTHON_LIBRARIES})
-target_include_directories(callpy PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
-    $<INSTALL_INTERFACE:include>
-    ${PYTHON_INCLUDE_DIRS}
-    )
+target_link_libraries(callpy PUBLIC Python::Python)
+
 
 install(TARGETS callpy
     EXPORT callpy
@@ -29,6 +25,6 @@ install(EXPORT callpy
 add_custom_command(
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/plugin.c
   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/builder.py ${CMAKE_CURRENT_SOURCE_DIR}/callpy.py
-  COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/builder.py ${CMAKE_CURRENT_SOURCE_DIR}/callpy.py
+  COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/builder.py ${CMAKE_CURRENT_SOURCE_DIR}/callpy.py
   COMMENT "Building CFFI Module"
 )


### PR DESCRIPTION
The previous FindPythonInterpreter is deprecated, and this new config
module simplifies the cmake usage.