### PR TITLE
Adjust settings for non-GNU compilers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,20 +5,24 @@ project(callpy)
 
 include(CTest)
 
-set(CMAKE_C_COMPILER       gcc)
-set(CMAKE_Fortran_COMPILER gfortran)
 
 if (${CMAKE_Fortran_COMPILER_ID} MATCHES GNU)
+    set(CMAKE_C_COMPILER       gcc)
+    set(CMAKE_Fortran_COMPILER gfortran)
     set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -g -Wall -Wextra -fimplicit-none -fbacktrace")
     set(CMAKE_Fortran_FLAGS_RELEASE "${CMAKE_Fortran_FLAGS_RELEASE} -Wno-error")
     set(CMAKE_Fortran_FLAGS_DEBUG "${CMAKE_Fortran_FLAGS_DEBUG} -fbounds-check --coverage")
 
 elseif(${CMAKE_Fortran_COMPILER_ID} MATCHES Intel)
+    set(CMAKE_C_COMPILER       icc)
+    set(CMAKE_Fortran_COMPILER ifort)
     set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -g -traceback -warn errors warn all")
     set(CMAKE_Fortran_FLAGS_RELEASE "${CMAKE_Fortran_FLAGS_RELEASE} -warn noerrors -xHost")
     set(CMAKE_Fortran_FLAGS_DEBUG "${CMAKE_Fortran_FLAGS_DEBUG} -check all")
 
 elseif(${CMAKE_Fortran_COMPILER_ID} MATCHES PGI)
+    set(CMAKE_C_COMPILER       pgcc)
+    set(CMAKE_Fortran_COMPILER pgfortran)
     set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -g -traceback -Mdclchk -Mstandard")
     set(CMAKE_Fortran_FLAGS_RELEASE "${CMAKE_Fortran_FLAGS_RELEASE} -gopt -fast")
     set(CMAKE_Fortran_FLAGS_DEBUG "${CMAKE_Fortran_FLAGS_DEBUG} -Mbounds -Mchkptr -Mchkstk")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ if (${CMAKE_Fortran_COMPILER_ID} MATCHES GNU)
 elseif(${CMAKE_Fortran_COMPILER_ID} MATCHES Intel)
     set(CMAKE_C_COMPILER       icc)
     set(CMAKE_Fortran_COMPILER ifort)
-    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -g -traceback -warn errors warn all")
+    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -g -traceback -warn errors -warn all")
     set(CMAKE_Fortran_FLAGS_RELEASE "${CMAKE_Fortran_FLAGS_RELEASE} -warn noerrors -xHost")
     set(CMAKE_Fortran_FLAGS_DEBUG "${CMAKE_Fortran_FLAGS_DEBUG} -check all")
 

--- a/src/callpy_mod.f90
+++ b/src/callpy_mod.f90
@@ -9,16 +9,16 @@ module callpy_mod
      function set_state_py(tag, t, nx, ny, nz) result(y) bind(c)
        use iso_c_binding
        character(c_char) :: tag
-       real(c_double) t(nx, ny, nz)
        integer(c_int) :: nx, ny, nz
+       real(c_double) t(nx, ny, nz)
        integer(c_int) :: y
      end function set_state_py
 
     function get_state_py(tag, t, n) result(y) bind(c)
       use iso_c_binding
       character(c_char) :: tag
-      real(c_double) t(n)
       integer(c_int) :: n, y
+      real(c_double) t(n)
     end function get_state_py
   end interface
 


### PR DESCRIPTION
This PR is a start at addressing #20.  It moves the setting of the C and fortran compilers within the if blocks and addresses a typo in the specification of the compiler flags (and then a subsequent compile error) with Intel compilers.

It does not address all issues, however.  In the case of Intel I currently am getting the following error when calling `make`:

<details>
<p>

```
$ make
mkdir -p build
mkdir -p build
cd build && cmake ..
-- The Fortran compiler identification is Intel 19.0.5.20190815
-- Cray Programming Environment 2.6.3 Fortran
-- Detecting Fortran compiler ABI info
-- Detecting Fortran compiler ABI info - done
-- Check for working Fortran compiler: /opt/cray/pe/craype/2.6.3/bin/ftn - skipped
-- Checking whether /opt/cray/pe/craype/2.6.3/bin/ftn supports Fortran 90
-- Checking whether /opt/cray/pe/craype/2.6.3/bin/ftn supports Fortran 90 - yes
-- The C compiler identification is Intel 19.0.5.20190815
-- The CXX compiler identification is Intel 19.0.5.20190815
-- Cray Programming Environment 2.6.3 C
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /opt/cray/pe/craype/2.6.3/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Cray Programming Environment 2.6.3 CXX
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /opt/cray/pe/craype/2.6.3/bin/CC - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found Python: /ncrc/home1/Spencer.Clark/conda/envs/call_py_fort/bin/python3.8 (found suitable version "3.8.13", minimum required is "3") found components: Interpreter Development Development.Module Development.Embed
CMake Warning (dev) at src/CMakeLists.txt:4 (add_library):
  ADD_LIBRARY called with SHARED option but the target platform does not
  support dynamic linking.  Building a STATIC library instead.  This may lead
  to problems.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning at CMakeLists.txt:35 (find_package):
  By not providing "FindPFUNIT.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "PFUNIT", but
  CMake did not find one.

  Could not find a package configuration file provided by "PFUNIT" with any
  of the following names:

    PFUNITConfig.cmake
    pfunit-config.cmake

  Add the installation prefix of "PFUNIT" to CMAKE_PREFIX_PATH or set
  "PFUNIT_DIR" to a directory containing one of the above files.  If "PFUNIT"
  provides a separate development package or SDK, be sure it has been
  installed.


-- Configuring done
-- Generating done
-- Build files have been written to: /ncrc/home1/Spencer.Clark/call_py_fort/build
make -C build
make[1]: Entering directory '/ncrc/home1/Spencer.Clark/call_py_fort/build'
make[2]: Entering directory '/ncrc/home1/Spencer.Clark/call_py_fort/build'
make[3]: Entering directory '/ncrc/home1/Spencer.Clark/call_py_fort/build'
[ 10%] Building CFFI Module
generating plugin.c
Scanning dependencies of target callpy
make[3]: Leaving directory '/ncrc/home1/Spencer.Clark/call_py_fort/build'
make[3]: Entering directory '/ncrc/home1/Spencer.Clark/call_py_fort/build'
[ 20%] Building Fortran object src/CMakeFiles/callpy.dir/callpy_mod.f90.o
[ 30%] Building C object src/CMakeFiles/callpy.dir/plugin.c.o
[ 40%] Linking Fortran static library libcallpy.a
make[3]: Leaving directory '/ncrc/home1/Spencer.Clark/call_py_fort/build'
[ 40%] Built target callpy
make[3]: Entering directory '/ncrc/home1/Spencer.Clark/call_py_fort/build'
Scanning dependencies of target initialize_stuff
make[3]: Leaving directory '/ncrc/home1/Spencer.Clark/call_py_fort/build'
make[3]: Entering directory '/ncrc/home1/Spencer.Clark/call_py_fort/build'
[ 50%] Building Fortran object examples/CMakeFiles/initialize_stuff.dir/initialize_stuff.f90.o
[ 60%] Linking Fortran executable initialize_stuff
/usr/lib64/gcc/x86_64-suse-linux/7/../../../../x86_64-suse-linux/bin/ld: /ncrc/home1/Spencer.Clark/conda/envs/call_py_fort/bin/python3.8: stdin: invalid version 3 (max 0)
/usr/lib64/gcc/x86_64-suse-linux/7/../../../../x86_64-suse-linux/bin/ld: /ncrc/home1/Spencer.Clark/conda/envs/call_py_fort/bin/python3.8: error adding symbols: bad value
make[3]: *** [examples/CMakeFiles/initialize_stuff.dir/build.make:98: examples/initialize_stuff] Error 1
make[3]: Leaving directory '/ncrc/home1/Spencer.Clark/call_py_fort/build'
make[2]: *** [CMakeFiles/Makefile2:902: examples/CMakeFiles/initialize_stuff.dir/all] Error 2
make[2]: Leaving directory '/ncrc/home1/Spencer.Clark/call_py_fort/build'
make[1]: *** [Makefile:146: all] Error 2
make[1]: Leaving directory '/ncrc/home1/Spencer.Clark/call_py_fort/build'
make: *** [Makefile:5: all] Error 2
```

</p>
</details>

While in the case of PGI, I am getting the following error:

<details>
<p>

```
$ make
mkdir -p build
mkdir -p build
cd build && cmake ..
-- The Fortran compiler identification is PGI 19.10.0
-- Detecting Fortran compiler ABI info
-- Detecting Fortran compiler ABI info - done
-- Check for working Fortran compiler: /opt/pgi/19.10.0/linux86-64/19.10/bin/pgfortran - skipped
-- Checking whether /opt/pgi/19.10.0/linux86-64/19.10/bin/pgfortran supports Fortran 90
-- Checking whether /opt/pgi/19.10.0/linux86-64/19.10/bin/pgfortran supports Fortran 90 - yes
-- The C compiler identification is PGI 19.10.0
-- The CXX compiler identification is PGI 19.10.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /opt/pgi/19.10.0/linux86-64/19.10/bin/pgcc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /opt/pgi/19.10.0/linux86-64/19.10/bin/pgc++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found Python: /ncrc/home1/Spencer.Clark/conda/envs/call_py_fort/bin/python3.8 (found suitable version "3.8.13", minimum required is "3") found components: Interpreter Development Development.Module Development.Embed
CMake Warning at CMakeLists.txt:35 (find_package):
  By not providing "FindPFUNIT.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "PFUNIT", but
  CMake did not find one.

  Could not find a package configuration file provided by "PFUNIT" with any
  of the following names:

    PFUNITConfig.cmake
    pfunit-config.cmake

  Add the installation prefix of "PFUNIT" to CMAKE_PREFIX_PATH or set
  "PFUNIT_DIR" to a directory containing one of the above files.  If "PFUNIT"
  provides a separate development package or SDK, be sure it has been
  installed.


-- Configuring done
-- Generating done
-- Build files have been written to: /ncrc/home1/Spencer.Clark/call_py_fort/build
make -C build
make[1]: Entering directory '/ncrc/home1/Spencer.Clark/call_py_fort/build'
make[2]: Entering directory '/ncrc/home1/Spencer.Clark/call_py_fort/build'
make[3]: Entering directory '/ncrc/home1/Spencer.Clark/call_py_fort/build'
[ 10%] Building CFFI Module
generating plugin.c
Scanning dependencies of target callpy
make[3]: Leaving directory '/ncrc/home1/Spencer.Clark/call_py_fort/build'
make[3]: Entering directory '/ncrc/home1/Spencer.Clark/call_py_fort/build'
[ 20%] Building Fortran object src/CMakeFiles/callpy.dir/callpy_mod.f90.o
[ 30%] Building C object src/CMakeFiles/callpy.dir/plugin.c.o
[ 40%] Linking Fortran shared library libcallpy.so
make[3]: Leaving directory '/ncrc/home1/Spencer.Clark/call_py_fort/build'
[ 40%] Built target callpy
make[3]: Entering directory '/ncrc/home1/Spencer.Clark/call_py_fort/build'
Scanning dependencies of target initialize_stuff
make[3]: Leaving directory '/ncrc/home1/Spencer.Clark/call_py_fort/build'
make[3]: Entering directory '/ncrc/home1/Spencer.Clark/call_py_fort/build'
[ 50%] Building Fortran object examples/CMakeFiles/initialize_stuff.dir/initialize_stuff.f90.o
[ 60%] Linking Fortran executable initialize_stuff
/usr/bin/ld: ../src/libcallpy.so: undefined reference to `__sync_bool_compare_and_swap'
make[3]: *** [examples/CMakeFiles/initialize_stuff.dir/build.make:98: examples/initialize_stuff] Error 2
make[3]: Leaving directory '/ncrc/home1/Spencer.Clark/call_py_fort/build'
make[2]: *** [CMakeFiles/Makefile2:902: examples/CMakeFiles/initialize_stuff.dir/all] Error 2
make[2]: Leaving directory '/ncrc/home1/Spencer.Clark/call_py_fort/build'
make[1]: *** [Makefile:146: all] Error 2
make[1]: Leaving directory '/ncrc/home1/Spencer.Clark/call_py_fort/build'
make: *** [Makefile:5: all] Error 2
```

</p>
</details>